### PR TITLE
support for additional API settings

### DIFF
--- a/R/redcap_read.R
+++ b/R/redcap_read.R
@@ -99,6 +99,7 @@ redcap_read <- function( redcap_uri, token, records=NULL, records_collapsed=NULL
     , format = 'csv'
     , type = 'flat'
     , rawOrLabel = rawOrLabel
+    , exportDataAccessGroups = exportDataAccessGroups
     , records = records_collapsed
     , fields = fields_collapsed
     , .opts = curl_options


### PR DESCRIPTION
This adds support for the `rawOrLabel` and `exportDataAccessGroups` settings in the REDCap API call.
