### PR TITLE
Replacing "upload" with "download"

### DIFF
--- a/man/redcap_download_file_oneshot.Rd
+++ b/man/redcap_download_file_oneshot.Rd
@@ -2,6 +2,7 @@
 \name{redcap_download_file_oneshot}
 \alias{redcap_download_file_oneshot}
 \title{Download a file from a REDCap project record.}
+\Description{This function uses REDCaps API to download a file}
 \usage{
 redcap_download_file_oneshot(file_name = NULL, directory = NULL,
   overwrite = FALSE, redcap_uri, token, record, field, event = "",


### PR DESCRIPTION
&@wibeasley

I am not sure if this is the best way to recommend changes to the DocumentationPeek pdf, but I did notice a couple of typos that might confuse the inexperienced programmer.

Under the heading for the redcap_download_file_oneshot function, the description reads:

```
Description:
    This function uses REDCap's API to upload a file
```

When I think you meant "This function uses REDCap's API to _download_ a file.
