### PR TITLE
sslversion via function parameter

### DIFF
--- a/R/redcap_download_file_oneshot.R
+++ b/R/redcap_download_file_oneshot.R
@@ -18,6 +18,7 @@
 #' @param event The name of the event where the file is saved in REDCap. Optional
 #' @param verbose A boolean value indicating if \code{message}s should be printed to the R console during the operation.  Optional.
 #' @param cert_location  If present, this string should point to the location of the cert files required for SSL verification.  If the value is missing or NULL, the server's identity will be verified using a recent CA bundle from the \href{http://curl.haxx.se}{cURL website}.  See the details below. Optional.
+#' @param sslversion The SSL version for curl. The default is 3. Set to NULL if your server has disabled SSL v3.
 #' 
 #' @return Currently, a list is returned with the following elements,
 #' \enumerate{

--- a/R/redcap_metadata_read.R
+++ b/R/redcap_metadata_read.R
@@ -14,6 +14,7 @@
 #' @param fields_collapsed A single string, where the desired field names are separated by commas.  Optional.
 #' @param verbose A boolean value indicating if \code{message}s should be printed to the R console during the operation.  The verbose output might contain sensitive information (\emph{e.g.} PHI), so turn this off if the output might be visible somewhere public. Optional.
 #' @param cert_location  If present, this string should point to the location of the cert files required for SSL verification.  If the value is missing or NULL, the server's identity will be verified using a recent CA bundle from the \href{http://curl.haxx.se}{cURL website}.  See the details below. Optional.
+#' @param sslversion The SSL version for curl. The default is 3. Set to NULL if your server has disabled SSL v3.
 #' 
 #' @return Currently, a list is returned with the following elements,
 #' \enumerate{

--- a/R/redcap_read.R
+++ b/R/redcap_read.R
@@ -21,6 +21,7 @@
 #' @param raw_or_label A string (either \code{'raw'} or \code{'label'} that specifies whether to export the raw coded values or the labels for the options of multiple choice fields.  Default is \code{'raw'}.
 #' @param verbose A boolean value indicating if \code{message}s should be printed to the R console during the operation.  The verbose output might contain sensitive information (\emph{e.g.} PHI), so turn this off if the output might be visible somewhere public. Optional.
 #' @param cert_location  If present, this string should point to the location of the cert files required for SSL verification.  If the value is missing or NULL, the server's identity will be verified using a recent CA bundle from the \href{http://curl.haxx.se}{cURL website}.  See the details below. Optional.
+#' @param sslversion The SSL version for curl. The default is 3. Set to NULL if your server has disabled SSL v3.
 #' @param id_position  The column position of the variable that unique identifies the subject.  This defaults to the first variable in the dataset.
 #' 
 #' @return Currently, a list is returned with the following elements,

--- a/R/redcap_read_oneshot.R
+++ b/R/redcap_read_oneshot.R
@@ -16,6 +16,7 @@
 #' @param raw_or_label A string (either \code{'raw'} or \code{'label'} that specifies whether to export the raw coded values or the labels for the options of multiple choice fields.  Default is \code{'raw'}.
 #' @param verbose A boolean value indicating if \code{message}s should be printed to the R console during the operation.  The verbose output might contain sensitive information (\emph{e.g.} PHI), so turn this off if the output might be visible somewhere public. Optional.
 #' @param cert_location  If present, this string should point to the location of the cert files required for SSL verification.  If the value is missing or NULL, the server's identity will be verified using a recent CA bundle from the \href{http://curl.haxx.se}{cURL website}.  See the details below. Optional.
+#' @param sslversion The SSL version for curl. The default is 3. Set to NULL if your server has disabled SSL v3.
 #' @return Currently, a list is returned with the following elements,
 #' \enumerate{
 #'  \item \code{data}: An R \code{data.frame} of the desired records and columns.

--- a/R/redcap_upload_file_oneshot.R
+++ b/R/redcap_upload_file_oneshot.R
@@ -14,6 +14,7 @@
 #' @param event The name of the event where the file is saved in REDCap. Optional
 #' @param verbose A boolean value indicating if \code{message}s should be printed to the R console during the operation.  Optional.
 #' @param cert_location  If present, this string should point to the location of the cert files required for SSL verification.  If the value is missing or NULL, the server's identity will be verified using a recent CA bundle from the \href{http://curl.haxx.se}{cURL website}.  See the details below. Optional.
+#' @param sslversion The SSL version for curl. The default is 3. Set to NULL if your server has disabled SSL v3.
 #' 
 #' @return Currently, a list is returned with the following elements,
 #' \enumerate{

--- a/R/redcap_write.R
+++ b/R/redcap_write.R
@@ -14,6 +14,7 @@
 #' @param token The user-specific string that serves as the password for a project.  Required.
 #' @param verbose A boolean value indicating if \code{message}s should be printed to the R console during the operation.  The verbose output might contain sensitive information (\emph{e.g.} PHI), so turn this off if the output might be visible somewhere public. Optional.
 #' @param cert_location  If present, this string should point to the location of the cert files required for SSL verification.  If the value is missing or NULL, the server's identity will be verified using a recent CA bundle from the \href{http://curl.haxx.se}{cURL website}.  See the details below. Optional.
+#' @param sslversion The SSL version for curl. The default is 3. Set to NULL if your server has disabled SSL v3.
 #' 
 #' @return Currently, a list is returned with the following elements,
 #' \enumerate{

--- a/R/redcap_write_oneshot.R
+++ b/R/redcap_write_oneshot.R
@@ -11,6 +11,7 @@
 #' @param token The user-specific string that serves as the password for a project.  Required.
 #' @param verbose A boolean value indicating if \code{message}s should be printed to the R console during the operation.  The verbose output might contain sensitive information (\emph{e.g.} PHI), so turn this off if the output might be visible somewhere public. Optional.
 #' @param cert_location  If present, this string should point to the location of the cert files required for SSL verification.  If the value is missing or NULL, the server's identity will be verified using a recent CA bundle from the \href{http://curl.haxx.se}{cURL website}.  See the details below. Optional.
+#' @param sslversion The SSL version for curl. The default is 3. Set to NULL if your server has disabled SSL v3.
 #' 
 #' @return Currently, a list is returned with the following elements,
 #' \enumerate{


### PR DESCRIPTION
Moved the sslversion config to a parameter rather than being hardcoded. Default remains 3. Fixes #55 
