### PR TITLE
remove dev versions (of curl & httr) on testing platforms

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,9 @@ apt_packages:
   - unixodbc-dev
 r_github_packages:
   - jimhester/covr
-  - tidyverse/dplyr
-  - jeroen/curl
-  - r-lib/httr
+# - tidyverse/dplyr
+# - jeroen/curl
+# - r-lib/httr
 # - hadley/testthat
 after_success:
   - Rscript -e 'library(covr);coveralls()'

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -7,7 +7,7 @@ Description: Encapsulates functions to streamline calls from R to the REDCap
     to access and modify data programmatically, improving the capacity for
     literate and reproducible programming.
 Version: 0.9.8.9000
-Date: 2017-07-22
+Date: 2017-08-16
 Authors@R: c(person("Will", "Beasley", role = c("aut", "cre"), email =
     "wibeasley@hotmail.com"), person("David", "Bard", role = "ctb"),
     person("Thomas", "Wilson", role = "ctb"), person(given="John J",

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,7 +13,7 @@ install:
 
 build_script:
   - travis-tool.sh install_deps
-  - travis-tool.sh install_github r-lib/httr
+# - travis-tool.sh install_github r-lib/httr
 
 test_script:
   - travis-tool.sh run_tests


### PR DESCRIPTION
Now that they're updated on CRAN.  See #165 and https://github.com/r-lib/httr/releases/tag/v1.3.0