### PR TITLE
include RTools in AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,6 +10,8 @@ install:
   ps: Bootstrap
 
 # Adapt as necessary starting from here
+environment:
+  USE_RTOOLS: true # Set to false if no GitHub packages are necessary
 
 build_script:
   - travis-tool.sh install_deps


### PR DESCRIPTION
to hopefully avoid errors like [this](https://ci.appveyor.com/project/wibeasley/redcapr/build/1.0.497#L356)

```
3551: In missing_devel_warning(pkgdir) :
356  Package pkgload has compiled code, but no suitable compiler(s) were found. Installation will likely fail.
357  Install Rtools and make sure it is in the PATH.
3582: running command '"c:/R/bin/i386/R" CMD INSTALL -l "c:\RLibrary" "C:/Users/appveyor/AppData/Local/Temp/1/RtmpozcNq1/remotes44c13c94a4/r-lib-pkgload-0cd9f8d"' had status 1
3593: In i.p(...) :
360  installation of package 'C:/Users/appveyor/AppData/Local/Temp/1/RtmpozcNq1/remotes44c13c94a4/r-lib-pkgload-0cd9f8d' had non-zero exit status
361travis-tool.sh install_github r-lib/pkgload
362+ CRAN=https://cran.rstudio.com
363+ BIOC=http://bioconductor.org/biocLite.R
364
```