### PR TITLE
Convert markup links to roxygen commands

### DIFF
--- a/R/redcap-version.R
+++ b/R/redcap-version.R
@@ -10,10 +10,10 @@
 #' @param config_options  A list of options to pass to `POST` method in the `httr` package.  See the details below.  Optional.
 #'
 #' @details If the API call is unsuccessful, a value of `base::package_version("0.0.0")` will be returned.
-#' This ensures that a the function will always return an object of class [base::package_version].
+#' This ensures that a the function will always return an object of class \code{\link[base:numeric_version]{base::package_version}}.
 #' It guarantees the value can always be used in [utils::compareVersion()].
 #'
-#' @return A [utils::packageVersion].
+#' @return a \code{\link[utils:packageDescription]{utils::packageVersion}}.
 #' @examples
 #' uri      <- "https://bbmc.ouhsc.edu/redcap/api/"
 #' token    <- "9A81268476645C4E5F03428B8AC3AA7B"


### PR DESCRIPTION
Markup was used to link to help documentation for base::package_version() in @details and utils::packageVersion() in @return, but those functions do not have individual help files. Instead, they link to the common help files for base::numeric_version() and utils::packageDescription() respectively. Because the markup approach does not allow to point to the common help files ala https://github.com/klutometis/roxygen/issues/707, the markup was replaced with corresponding roxygen formatting commands. This patch will remove the error messages for missing files during package installation.