### PR TITLE
Support special characters in checkbox_choices()

### DIFF
--- a/R/metadata-utilities.R
+++ b/R/metadata-utilities.R
@@ -114,9 +114,7 @@ regex_named_captures <- function(pattern, text, perl = TRUE) {
 checkbox_choices <- function(select_choices) {
   checkmate::assert_character(select_choices, any.missing=FALSE, len=1, min.chars=1)
 
-  # The weird ranges are to avoid the pipe character;
-  #   PCRE doesn't support character negation.
-  pattern_checkboxes <- "(?<=\\A| \\| )(?<id>\\d{1,}), (?<label>[\x21-\x7B\x7D-\x7E ]{1,})(?= \\| |\\Z)"
+  pattern_checkboxes <- "(?<=\\A| \\| )(?<id>\\d{1,}), (?<label>[^|]{1,})(?= \\| |\\Z)"
 
   regex_named_captures(pattern = pattern_checkboxes, text = select_choices)
 }

--- a/tests/testthat/test-metadata-utilities.R
+++ b/tests/testthat/test-metadata-utilities.R
@@ -20,8 +20,6 @@ test_that("Named Captures", {
 })
 
 test_that("checkbox choices", {
-  pattern_checkboxes <- "(?<=\\A| \\| )(?<id>\\d{1,}), (?<label>[\x20-\x7B\x7D-\x7E]{1,})(?= \\| |\\Z)"
-
   choices_1 <- "1, American Indian/Alaska Native | 2, Asian | 3, Native Hawaiian or Other Pacific Islander | 4, Black or African American | 5, White | 6, Unknown / Not Reported"
   ds_boxes <- checkbox_choices(select_choices=choices_1)
 
@@ -35,5 +33,23 @@ test_that("checkbox choices", {
   )
 
   expect_equal(ds_boxes, expected=ds_expected, label="The returned data.frame should be correct") #dput(ds_boxes)
+  expect_s3_class(ds_boxes, "tbl")
+})
+
+
+test_that("checkbox choices with special characters", {
+  choices_1 <- "1, Hospital A | 2, Hospitäl B | 3, Hospital Ç | 4, Hospítal D"
+  ds_boxes <- checkbox_choices(select_choices=choices_1)
+
+  ds_expected <- structure(
+    list(
+      id = c("1", "2", "3", "4"),
+      label = c("Hospital A", "Hospitäl B", "Hospital Ç", "Hospítal D")
+    ),
+    class = c("tbl_df", "tbl", "data.frame"),
+    row.names = c(NA, -4L)
+  )
+
+  expect_equal(ds_boxes, expected=ds_expected, label="The returned data.frame should be correct")
   expect_s3_class(ds_boxes, "tbl")
 })


### PR DESCRIPTION
Fixes #462 

There was a comment about how PCRE didn't support negation, but this works on my Mac with R>4.0. It'll be interesting to see if this causes trouble for other operating sytems/R versions.