### PR TITLE
build col spec matching project info response

### DIFF
--- a/R/redcap-metadata-coltypes.R
+++ b/R/redcap-metadata-coltypes.R
@@ -301,6 +301,16 @@ redcap_metadata_internal <- function(
       )
   }
 
+  if (is.na(d_proj$has_repeating_instruments_or_events[1]))
+    stop(
+      sprintf(
+        paste(
+          "The REDCap instance at %s failed to report if the",
+          "current project uses repeatable instruments or events."
+        ),
+        redcap_uri
+      )
+    )
   if (d_proj$has_repeating_instruments_or_events[1]) {
     d_again <-
       d_again %>%


### PR DESCRIPTION
This pull request addresses issue [465](https://github.com/OuhscBbmc/REDCapR/issues/465) where {REDCapR} fails to retrieve project records on older versions of REDCap (~7.3.5).

The root cause of the issue is that older versions of REDCap fail to report all project information expected by {REDCapR}. The most critical missing project information is whether a project uses repeatable instruments or events. 

The issue is addressed by:
1. adaptively building a column specification that matches the columns returned by the project information endpoint
2. halting the reading of records with a message in the event of a REDCap failure to report on repeatable instruments or events usage in the project