### PR TITLE
add drop = FALSE to ds_to_write[selected_indicies, ]

### DIFF
--- a/R/redcap-write.R
+++ b/R/redcap-write.R
@@ -170,7 +170,7 @@ redcap_write <- function(
     }
 
     write_result <- REDCapR::redcap_write_oneshot(
-      ds                          = ds_to_write[selected_indices, ],
+      ds                          = ds_to_write[selected_indices, ,drop = FALSE],
       redcap_uri                  = redcap_uri,
       token                       = token,
       overwrite_with_blanks       = overwrite_with_blanks,


### PR DESCRIPTION
prevents dropping dimensions from ds_to_write if class is data.frame and contains only one column