### PR TITLE
e+05 Resolution

### DIFF
--- a/R/redcap-write-oneshot.R
+++ b/R/redcap-write-oneshot.R
@@ -99,6 +99,22 @@
 #' result_write$raw_text
 #' }
 
+serialize_csv_for_write <- function(ds) {
+  csv_elements <- NULL
+  old_options <- options(scipen = 999)
+  on.exit(options(old_options), add = TRUE)
+
+  con <- base::textConnection(
+    object  = "csv_elements",
+    open    = "w",
+    local   = TRUE
+  )
+  on.exit(close(con), add = TRUE)
+
+  utils::write.csv(ds, con, row.names = FALSE, na = "")
+  paste(csv_elements, collapse = "\n")
+}
+
 #' @importFrom magrittr %>%
 #' @export
 redcap_write_oneshot <- function(
@@ -111,11 +127,6 @@ redcap_write_oneshot <- function(
   config_options                = NULL,
   handle_httr                   = NULL
 ) {
-
-  # This prevents the R CHECK NOTE: 'No visible binding for global variable Note in R CMD check';
-  # Also see  if( getRversion() >= "2.15.1" )    utils::globalVariables(names=c("csv_elements"))
-  # https://stackoverflow.com/questions/8096313/; https://stackoverflow.com/questions/9439256
-  csv_elements <- NULL
 
   checkmate::assert_character(redcap_uri, any.missing=FALSE, len=1, pattern="^.{1,}$")
   checkmate::assert_character(token     , any.missing=FALSE, len=1, pattern="^.{1,}$")
@@ -130,16 +141,7 @@ redcap_write_oneshot <- function(
       dplyr::mutate_if(is.logical, as.integer)
   }
 
-  con     <-  base::textConnection(
-    object  = "csv_elements",
-    open    = "w",
-    local   = TRUE
-  )
-  utils::write.csv(ds, con, row.names = FALSE, na = "")
-  close(con)
-
-  csv     <- paste(csv_elements, collapse = "\n")
-  rm(csv_elements, con)
+  csv <- serialize_csv_for_write(ds)
 
   post_body <- list(
     token     = token,

--- a/tests/testthat/test-write-serialization.R
+++ b/tests/testthat/test-write-serialization.R
@@ -6,7 +6,7 @@ test_that("write serialization preserves large IDs without scientific notation",
 
   csv <- REDCapR:::serialize_csv_for_write(ds)
 
-  expect_match(csv, "\"100000\"", fixed = TRUE)
-  expect_match(csv, "\"200000\"", fixed = TRUE)
+  expect_match(csv, "100000,\"b\"", fixed = TRUE)
+  expect_match(csv, "200000,\"c\"", fixed = TRUE)
   expect_false(grepl("1e\\+05|2e\\+05", csv))
 })

--- a/tests/testthat/test-write-serialization.R
+++ b/tests/testthat/test-write-serialization.R
@@ -1,0 +1,12 @@
+test_that("write serialization preserves large IDs without scientific notation", {
+  ds <- data.frame(
+    record_id = c(99999, 100000, 200000),
+    value = c("a", "b", "c")
+  )
+
+  csv <- REDCapR:::serialize_csv_for_write(ds)
+
+  expect_match(csv, "\"100000\"", fixed = TRUE)
+  expect_match(csv, "\"200000\"", fixed = TRUE)
+  expect_false(grepl("1e\\+05|2e\\+05", csv))
+})


### PR DESCRIPTION
## Summary
This fixes REDCap record import serialization for larger numeric record IDs.

Before this change, IDs such as `100000`, `200000`, and `400000` could be serialized in scientific notation during CSV upload, which could cause REDCap import failures or incorrect record identification.

## What Changed
- Added an internal CSV serialization helper for write/import operations.
- Forced non-scientific numeric formatting during upload serialization.
- Updated `redcap_write_oneshot()` to use the helper.
- Added a focused regression test covering large record ID serialization.

## Why This Is Small and Safe
This change is limited to the CSV generation path used for record writes. It does not change the API contract, request shape, or read behavior.

## Example
Values like these are now serialized as plain values instead of scientific notation:
- `100000`
- `200000`
- `400000`