### PR TITLE
Fix bug where REDCapR::validate_for_write() does not recognize an alternative record ID name.

### DIFF
--- a/R/validate.R
+++ b/R/validate.R
@@ -395,7 +395,7 @@ validate_for_write <- function(
   lst_concerns <- list(
     validate_data_frame_inherits(d),
     validate_field_names(d),
-    validate_record_id_name(d),
+    validate_record_id_name(d, record_id_name = record_id_name),
     validate_uniqueness(d, record_id_name = record_id_name),
     validate_repeat_instance(d)
   )

--- a/tests/testthat/test-validate.R
+++ b/tests/testthat/test-validate.R
@@ -32,6 +32,16 @@ test_that("validate_for_write_no_errors - convert_logical_to_integer", {
   expect_equal(object = nrow(ds), expected = 0)
 })
 
+test_that("validate_for_write_no_errors - record_id_name", {
+  d <-
+    data.frame(
+      id = 1:4
+    )
+
+  ds <- validate_for_write(d, record_id_name = "id")
+  expect_equal(object = nrow(ds), expected = 0)
+})
+
 test_that("not a data.frame", {
   error_pattern <- "The `d` object is not a valid `data\\.frame`\\."
   expect_error(


### PR DESCRIPTION
Simple fix. I just passed the "record_id_name" argument to the `validate_record_id_name()` function call inside `validate_for_write()`. I also added a test to test-validate.R file.

This is my first open-source contribution so please let me know if I did anything incorrectly.

Closes #601 