### PR TITLE
avoid scientific notation when writing

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -6,7 +6,7 @@ Description: Encapsulates functions to streamline calls from R to the REDCap
     University.  The Application Programming Interface (API) offers an avenue
     to access and modify data programmatically, improving the capacity for
     literate and reproducible programming.
-Version: 1.6.0.9001
+Version: 1.6.0.9002
 Authors@R: c(person("Will", "Beasley", role = c("aut", "cre"), email =
     "wibeasley@hotmail.com", comment = c(ORCID = "0000-0002-5613-5006")),
     person("David", "Bard", role = "ctb", comment = c(ORCID = "0000-0002-3922-8489")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -15,6 +15,10 @@
 * Update deprecated parameters for `base::structure (#605)
 * `validate_for_write()` now accommodates projects with a custom name for `record_id` (#601, #602, @vanbibn)
 
+### Bug fixes
+
+* When writing to the server, a numeric value like "10000" will not be converted to scientific notation (#599, #600, @Olawemi5)
+
 # REDCapR 1.6.0  (released 2025-10-07)
 
 This release is primarily small changes to comply with a CRAN check.

--- a/R/redcap-write-oneshot.R
+++ b/R/redcap-write-oneshot.R
@@ -189,18 +189,10 @@ redcap_write_oneshot <- function(
   )
 }
 
-serialize_csv_for_write <- function(ds) {
-  csv_elements <- NULL
-  old_options <- options(scipen = 999)
-  on.exit(options(old_options), add = TRUE)
-
-  con <- base::textConnection(
-    object  = "csv_elements",
-    open    = "w",
-    local   = TRUE
+serialize_csv_for_write <- function(d) {
+  readr::format_csv(
+    x     = d,
+    na    = "",
+    quote = "all"
   )
-  on.exit(close(con), add = TRUE)
-
-  utils::write.csv(ds, con, row.names = FALSE, na = "")
-  paste(csv_elements, collapse = "\n")
 }

--- a/R/redcap-write-oneshot.R
+++ b/R/redcap-write-oneshot.R
@@ -99,21 +99,6 @@
 #' result_write$raw_text
 #' }
 
-serialize_csv_for_write <- function(ds) {
-  csv_elements <- NULL
-  old_options <- options(scipen = 999)
-  on.exit(options(old_options), add = TRUE)
-
-  con <- base::textConnection(
-    object  = "csv_elements",
-    open    = "w",
-    local   = TRUE
-  )
-  on.exit(close(con), add = TRUE)
-
-  utils::write.csv(ds, con, row.names = FALSE, na = "")
-  paste(csv_elements, collapse = "\n")
-}
 
 #' @importFrom magrittr %>%
 #' @export
@@ -202,4 +187,20 @@ redcap_write_oneshot <- function(
     elapsed_seconds           = kernel$elapsed_seconds,
     raw_text                  = kernel$raw_text
   )
+}
+
+serialize_csv_for_write <- function(ds) {
+  csv_elements <- NULL
+  old_options <- options(scipen = 999)
+  on.exit(options(old_options), add = TRUE)
+
+  con <- base::textConnection(
+    object  = "csv_elements",
+    open    = "w",
+    local   = TRUE
+  )
+  on.exit(close(con), add = TRUE)
+
+  utils::write.csv(ds, con, row.names = FALSE, na = "")
+  paste(csv_elements, collapse = "\n")
 }

--- a/tests/testthat/test-write-serialization.R
+++ b/tests/testthat/test-write-serialization.R
@@ -1,12 +1,13 @@
 test_that("write serialization preserves large IDs without scientific notation", {
   ds <- data.frame(
-    record_id = c(99999, 100000, 200000),
-    value = c("a", "b", "c")
+    record_id = c(99999, 100000, NA, 200000),
+    value = c("a", "b", "c", "d")
   )
 
   csv <- REDCapR:::serialize_csv_for_write(ds)
 
   expect_match(csv, "100000,\"b\"", fixed = TRUE)
-  expect_match(csv, "200000,\"c\"", fixed = TRUE)
+  expect_match(csv, ",\"c\"", fixed = TRUE)
+  expect_match(csv, "200000,\"d\"", fixed = TRUE)
   expect_false(grepl("1e\\+05|2e\\+05", csv))
 })

--- a/tests/testthat/test-write-serialization.R
+++ b/tests/testthat/test-write-serialization.R
@@ -4,10 +4,9 @@ test_that("write serialization preserves large IDs without scientific notation",
     value = c("a", "b", "c", "d")
   )
 
-  csv <- REDCapR:::serialize_csv_for_write(ds)
+  expected  <- "\"record_id\",\"value\"\n99999,\"a\"\n100000,\"b\"\n,\"c\"\n200000,\"d\""
+  observed  <- REDCapR:::serialize_csv_for_write(ds)
 
-  expect_match(csv, "100000,\"b\"", fixed = TRUE)
-  expect_match(csv, ",\"c\"", fixed = TRUE)
-  expect_match(csv, "200000,\"d\"", fixed = TRUE)
-  expect_false(grepl("1e\\+05|2e\\+05", csv))
+  expect_equal(observed, expected)
+  expect_false(grepl("1e\\+05|2e\\+05", observed))
 })

--- a/tests/testthat/test-write-serialization.R
+++ b/tests/testthat/test-write-serialization.R
@@ -4,7 +4,7 @@ test_that("write serialization preserves large IDs without scientific notation",
     value = c("a", "b", "c", "d")
   )
 
-  expected  <- "\"record_id\",\"value\"\n99999,\"a\"\n100000,\"b\"\n,\"c\"\n200000,\"d\""
+  expected  <- "\"record_id\",\"value\"\n99999,\"a\"\n100000,\"b\"\n,\"c\"\n200000,\"d\"\n"
   observed  <- REDCapR:::serialize_csv_for_write(ds)
 
   expect_equal(observed, expected)


### PR DESCRIPTION
builds on @Olawemi5 code in #599 & #600